### PR TITLE
BK-3731: Set client default timeout and retries

### DIFF
--- a/hammock/templates/client/file.j2
+++ b/hammock/templates/client/file.j2
@@ -56,7 +56,7 @@ class {{ class_name }}(object):
 
     ROUTE_CLI_COMMAND_MAP = {}
 
-    def __init__(self, hostname=None, port=None, url={% if default_url %}'{{ default_url }}'{% else %}''{% endif %}, token=None, timeout=None, headers=None, retries=None, session=None):
+    def __init__(self, hostname=None, port=None, url={% if default_url %}'{{ default_url }}'{% else %}''{% endif %}, token=None, timeout=60, headers=None, retries=0, session=None):
         """
         :param url: url to connect to
         :param token: a token to be used for requests


### PR DESCRIPTION
Set default timeout to 60s
Set to no-retries by default.

This will solve clients that get stuck when waiting for replies,
After the service will regenerate the client

@Stratoscale/mgmt 