### PR TITLE
Fix treatment of empty value for query param

### DIFF
--- a/hammock/types/url.py
+++ b/hammock/types/url.py
@@ -51,10 +51,11 @@ class Url(object):
     @property
     def params(self):
         if not self._params:
+            query = urllib.parse.parse_qs(self.parsed.query, keep_blank_values=True)
             self._params = {
                 key: self._param_value(value)
-                for key, value in six.iteritems(urllib.parse.parse_qs(self.parsed.query))
-                }
+                for key, value in six.iteritems(query)
+            }
         return self._params
 
     @staticmethod


### PR DESCRIPTION
Don't discard a query param when its value is empty
or it's value is missing.
For example: '&foo' will result in query params
{foo: } rather then {}.

@roeih-stratoscale @Stratoscale/mgmt 