### PR TITLE
Roei/content type

### DIFF
--- a/hammock/types/request.py
+++ b/hammock/types/request.py
@@ -92,5 +92,6 @@ class Request(http_base.HttpBase):
                 return {common.KW_CONTENT: body}
         else:
             content_length = self.headers.get(common.CONTENT_LENGTH, '0')
-            if int(content_length) != 0:
+            if content_length.isdigit() and int(content_length) != 0:
                 return {common.KW_FILE: file_module.File(self.content, content_length)}
+            return None

--- a/hammock/types/response.py
+++ b/hammock/types/response.py
@@ -33,6 +33,7 @@ class Response(http_base.HttpBase):
         response_headers = result.pop(common.KW_HEADERS, {})
         content_stream = result.pop(common.KW_FILE, None)
         response_status = result.pop(common.KW_STATUS, status)
+        content_type = response_headers.get(common.CONTENT_TYPE, content_type)
 
         if content_stream:
             content = common.to_bytes(content_stream)


### PR DESCRIPTION
1) Allow to specifically set the content type using the headers
2) Gracefully handle a content-length value which is not a positive integer in a request header.

@eyal-stratoscale @Stratoscale/mgmt
