### PR TITLE
BK-4455: Handle http-keepalive race-condition

### DIFF
--- a/hammock/templates/client/file.j2
+++ b/hammock/templates/client/file.j2
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import os
+import logging
 import requests
 import requests.adapters
 import six
@@ -80,6 +81,7 @@ class {{ class_name }}(object):
             retries = retry.Retry(total=retries, read=0, backoff_factor=0.05, method_whitelist=METHOD_WHITELIST)
 
         self._client.mount(self._url, requests.adapters.HTTPAdapter(max_retries=retries))
+        self._logger = logging.getLogger(__name__)
         self._timeout = timeout
         self._set_token(token)
         self._client.headers.update(headers or {})
@@ -153,6 +155,7 @@ class {{ class_name }}(object):
                     if "BadStatusLine" in str(err) and "Connection aborted" in str(err):
                         retry = True
                         retry_count -= 1
+                        self._logger.warning("hammock - Got BadStatusLine from server - considering http-keepalive race-condition and retrying")
                     else:
                         raise
             result = None

--- a/hammock/templates/client/file.j2
+++ b/hammock/templates/client/file.j2
@@ -140,7 +140,21 @@ class {{ class_name }}(object):
             _kwargs.setdefault('headers', {}).update(headers)
         LOG.debug("Sending %s request: %s %s", method, url, json)
         try:
-            response = getattr(self._client, method.lower())(url, **_kwargs)
+            retry = True
+            retry_count = 3
+            while retry and retry_count > 0:
+                retry = False
+                try:
+                    response = getattr(self._client, method.lower())(url, **_kwargs)
+                except requests.ConnectionError, err:
+                    # There's a race condition in http-keepalive mechanism, that can cause a "BadStatusLine" exception.
+                    # If the error is because of it, the server didn't even get our request, so we should retry
+                    # See BK-4455 for more details
+                    if "BadStatusLine" in str(err) and "Connection aborted" in str(err):
+                        retry = True
+                        retry_count -= 1
+                    else:
+                        raise
             result = None
             if '{{ type_json }}' in response.headers.get('content-type', ''):
                 result = self._jsonify(response)


### PR DESCRIPTION
There's a race condition in http-keepalive mechanism, that can cause
a "BadStatusLine" exception. If it happens, the server didn't even
get our request, so it's safe and we should retry

Do I like it? no.
Did we manage to think of a better idea? no.

@eyal-stratoscale @adir-stratoscale @roeih-stratoscale @Stratoscale/mgmt 