### PR TITLE
Logging improvements

### DIFF
--- a/hammock/common.py
+++ b/hammock/common.py
@@ -41,6 +41,9 @@ POST = 'POST'
 DELETE = 'DELETE'
 PATCH = 'PATCH'
 
+# REST methods not to log
+REST_METHODS_LOGGING_BLACKLIST = [GET]
+
 CONTENT_CONVERSION = {TYPE_JSON: json.dumps, TYPE_XML: ElementTree.tostring}
 
 

--- a/hammock/wrappers/_route.py
+++ b/hammock/wrappers/_route.py
@@ -76,6 +76,14 @@ class Route(wrapper.Wrapper):
             # we have no need in parsing the kwargs
             return proxy.proxy(req, self.dest)
 
+        # uWSGI bonus - if this is not a GET request, log it
+        try:
+            import uwsgi
+            if req.method not in common.REST_METHODS_LOGGING_BLACKLIST:
+                uwsgi.log_this_request()
+        except:
+            pass
+
         kwargs = req.collected_data
         self._convert_by_keyword_map(kwargs)
         enforcer = None


### PR DESCRIPTION
If uWSGI is used, we can now auto-log all requests which aren't GET

@rom-stratoscale @ravid-stratoscale @eyal-stratoscale @yossi-stratoscale 