### PR TITLE
omit token when printing kwargs to log

### DIFF
--- a/hammock/common.py
+++ b/hammock/common.py
@@ -10,6 +10,7 @@ import logging
 import random
 import string
 import time
+from copy import deepcopy
 
 import six
 
@@ -93,3 +94,11 @@ def to_bytes(source):
         # XXX: maybe more efficient way then reading StringIO data.
         return codecs.encode(source.getvalue(), ENCODING)
     return source
+
+
+def repr_kwargs(kwargs):
+    # token is too large to be printed
+    kw = deepcopy(kwargs)
+    if '_credentials' in kw:
+        kw['_credentials'].token = 'omitted'
+    return json.dumps(kw)

--- a/hammock/types/func_spec.py
+++ b/hammock/types/func_spec.py
@@ -5,7 +5,7 @@ import six
 import re
 import hammock.types.args as args
 import hammock
-
+from hammock.common import repr_kwargs
 
 PARAM_IS_SPECIAL = re.compile(r'^[ ]*:(param|return)')
 PARAM_RE = re.compile(r'^[ ]*:param([ ]+(?P<type>[\w\[\]]+))?[ ]+(?P<name>\w+):[ ]*(?P<doc>.*)$', re.MULTILINE)
@@ -39,9 +39,13 @@ class FuncSpec(object):
         missing = set(self.args) - keys
         not_expected = keys - self.all_args
         if missing:
-            raise TypeError('Missing arguments: {}. Expected at least: {}. Got: {}'.format(missing, self.args, kwargs))
+            raise TypeError(
+                'Missing arguments: {}. Expected at least: {}. Got: {}'.format(
+                    missing, self.args, repr_kwargs(kwargs)))
         if not self.keywords and not_expected:
-            raise TypeError('Got unexpected arguments: {}. Expect: {}. Got: {}.'.format(not_expected, self.all_args, kwargs))
+            raise TypeError(
+                'Got unexpected arguments: {}. Expect: {}. Got: {}.'.format(
+                    not_expected, self.all_args, repr_kwargs(kwargs)))
         self._convert_args(kwargs)
 
     def _collect_args_info(self, doc_args_info):

--- a/hammock/wrappers/_route.py
+++ b/hammock/wrappers/_route.py
@@ -101,7 +101,7 @@ class Route(wrapper.Wrapper):
         except exceptions.HttpError as exc:
             raise self._error(exceptions.BadRequest, str(exc))
         except Exception as exc:  # pylint: disable=broad-except
-            logging.exception('[Error parsing request kwargs %s] kwargs: %s, %r', req.uid, kwargs, exc)
+            logging.debug('[Error parsing request kwargs %s] kwargs: %s, %r', req.uid, common.repr_kwargs(kwargs), exc)
             raise self._error(exceptions.BadRequest, 'Error parsing request parameters, {}'.format(exc))
 
         if self.dest is None:


### PR DESCRIPTION
@eyal-stratoscale please review
Should resolve:

1. exception duplication caused by logging.exception of exception
2. error logging duplication for some errors once in wrapper and once in error handler
3. remove token (very very large string) from logging printouts