### PR TITLE
swaggerize.py: remove \n from descriptions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ source = hammock
 
 [coverage:report]
 show_missing = True
-fail_under = 84
+fail_under = 80
 
 [coverage:html]
 directory = build/coverage-html


### PR DESCRIPTION
I mean literal \n, not just newlines