### PR TITLE
Workaround the ujson bug in handling large numbers

### DIFF
--- a/hammock/converters.py
+++ b/hammock/converters.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
 import six
 import uuid
-try:
-    import ujson as json
-except ImportError:
-    import json
+import hammock.common as common
 
 
 def to_bool(value):
@@ -33,7 +30,7 @@ def to_dict(value):
         return {}
     dict_value = value
     if isinstance(value, six.string_types):
-        dict_value = json.loads(value)
+        dict_value = common.json_loads(value)
     if not isinstance(dict_value, dict):
         raise ValueError('Conversion to dict failed')
     return dict_value

--- a/hammock/exceptions.py
+++ b/hammock/exceptions.py
@@ -1,8 +1,4 @@
 from __future__ import absolute_import
-try:
-    import ujson as json
-except ImportError:
-    import json
 
 BAD_REQUEST = 400
 UNAUTHORIZED = 401
@@ -29,7 +25,8 @@ class HttpError(Exception):
 
     @property
     def to_json(self):
-        return json.dumps(self.to_dict)
+        import hammock.common as common  # import here to resolve circular reference
+        return common.json_dumps(self.to_dict)
 
     @property
     def to_dict(self):

--- a/hammock/testing/base.py
+++ b/hammock/testing/base.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import
 import collections
 import falcon
 import falcon.testing as testing
-try:
-    import ujson as json
-except ImportError:
-    import json
 import six
 import importlib
 import hammock
@@ -36,7 +32,7 @@ class TestBase(testing.TestBase):
             kwargs["query_string"] = query_string
         if body is not None:
             content_type = headers.get(common.CONTENT_TYPE, common.TYPE_JSON)
-            kwargs["body"] = json.dumps(body) if common.TYPE_JSON in content_type else body
+            kwargs["body"] = common.json_dumps(body) if common.TYPE_JSON in content_type else body
             headers.update({common.CONTENT_TYPE: content_type})
         kwargs["headers"] = headers
         response = self.simulate_request(url, method=method, **kwargs)
@@ -48,7 +44,7 @@ class TestBase(testing.TestBase):
             result = result.decode(common.ENCODING)
         headers = types.Headers(dict(self.srmock.headers))
         if not binary_response and common.TYPE_JSON in headers.get(common.CONTENT_TYPE, ''):
-            result = json.loads(result)
+            result = common.json_loads(result)
         return result
 
     def assert_status(self, status, *args, **kwargs):

--- a/hammock/testing/server.py
+++ b/hammock/testing/server.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import
 import six
 import threading
 import logging
-try:
-    import ujson as json
-except ImportError:
-    import json
 import socket
 import hammock.common as common
 
@@ -84,7 +80,7 @@ class Handler(six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler):
         if body and not isinstance(body, six.string_types):
             body = body.decode()
         if common.TYPE_JSON in self.headers.get(common.CONTENT_TYPE, ''):
-            body = json.loads(body)
+            body = common.json_loads(body)
         parsed = six.moves.urllib.parse.urlsplit(self.path)
         content = dict(
             method=method,
@@ -99,7 +95,7 @@ class Handler(six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler):
         if not self.headers.get(common.CONTENT_TYPE) or common.TYPE_JSON in self.headers[common.CONTENT_TYPE]:
             if isinstance(content, six.binary_type):
                 content = content.decode()  # pylint: disable=no-member
-            content = six.b(json.dumps(content))
+            content = six.b(common.json_dumps(content))
             self.send_header(common.CONTENT_LENGTH, len(content))
             self.send_header(common.CONTENT_TYPE, common.TYPE_JSON)
             self.end_headers()

--- a/hammock/types/http_base.py
+++ b/hammock/types/http_base.py
@@ -1,9 +1,5 @@
 from __future__ import absolute_import
 import io
-try:
-    import ujson as json
-except ImportError:
-    import json
 
 import hammock.common as common
 import hammock.exceptions as exceptions
@@ -50,7 +46,7 @@ class HttpBase(object):
             body = self.read()
             if body:
                 try:
-                    self._json = json.loads(body)
+                    self._json = common.json_loads(body)
                 except (ValueError, UnicodeDecodeError) as exc:
                     raise exceptions.MalformedJson(
                         "Could not parse json body {!r}: {!r}".format(body, exc))
@@ -62,7 +58,7 @@ class HttpBase(object):
         if data is None:
             self.content = None
         else:
-            self.content = json.dumps(data)
+            self.content = common.json_dumps(data)
             self.headers[common.CONTENT_TYPE] = common.TYPE_JSON
 
     @property

--- a/tests/resources1/patterns.py
+++ b/tests/resources1/patterns.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import six
-import ujson as json
 import hammock
 import hammock.common as common
 
@@ -20,7 +19,7 @@ class Patterns(hammock.Resource):
     @hammock.sink("{my_id}/extra")
     def get_id_metadata(self, request, my_id):  # pylint: disable=unused-argument
         return hammock.types.Response(
-            content=six.BytesIO(six.b(json.dumps('extra-%s') % my_id)),
+            content=six.BytesIO(six.b(common.json_dumps('extra-%s') % my_id)),
             status=200,
             headers={common.CONTENT_TYPE: common.TYPE_JSON},
         )
@@ -28,7 +27,7 @@ class Patterns(hammock.Resource):
     @hammock.sink("{my_id}/extra/specific")
     def get_id_metadata_specific(self, request, my_id):  # pylint: disable=unused-argument
         return hammock.types.Response(
-            content=six.BytesIO(six.b(json.dumps('extra-specific-%s') % my_id)),
+            content=six.BytesIO(six.b(common.json_dumps('extra-specific-%s') % my_id)),
             status=200,
             headers={common.CONTENT_TYPE: common.TYPE_JSON},
         )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import hammock.exceptions as exceptions
 import tests.base as base
 import tests.resources1.exceptions as exceptions_resource
-import ujson as json
+import hammock.common as common
 import logging
 
 
@@ -20,7 +20,7 @@ class TestExceptions(base.TestBase):
         self.assertEqual(bad_request.title, bad_request_dict['title'])
         self.assertEqual(bad_request.description, bad_request_dict['description'])
         self.assertDictEqual(bad_request.to_dict, bad_request_dict)
-        self.assertDictEqual(json.loads(bad_request.to_json), bad_request_dict)
+        self.assertDictEqual(common.json_loads(bad_request.to_json), bad_request_dict)
 
     def test_internal_server_error(self):
         logging.info("Testing for exception raising")


### PR DESCRIPTION
ujson library used by hammock cannot handle large integers
(causes OverflowError and ValueError on dumps and loads operations).

Fallback to the standard json parser which does not have this issue.