### PR TITLE
BK-4756: Populate request body for urlencoded content type

### DIFF
--- a/hammock/backends/_falcon.py
+++ b/hammock/backends/_falcon.py
@@ -42,8 +42,13 @@ class Falcon(backend.Backend):
 
     @staticmethod
     def _req_from_backend(backend_req, url_params):
+        if (backend_req.content_type is not None and
+                'application/x-www-form-urlencoded' in backend_req.content_type):
+            content = "&".join([k + "=" + backend_req.params[k] for k in backend_req.params])
+        else:
+            content = backend_req.stream
         return request.Request(
-            backend_req.method, backend_req.url, backend_req.headers, backend_req.stream, url_params)
+            backend_req.method, backend_req.url, backend_req.headers, content, url_params)
 
     @staticmethod
     def _update_backend_response(resp, backend_resp):

--- a/hammock/backends/_falcon.py
+++ b/hammock/backends/_falcon.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import six
 import re
 import logging
+import urllib
 import hammock.common as common
 import hammock.names as names
 import hammock.types.request as request
@@ -42,9 +43,8 @@ class Falcon(backend.Backend):
 
     @staticmethod
     def _req_from_backend(backend_req, url_params):
-        if (backend_req.content_type is not None and
-                'application/x-www-form-urlencoded' in backend_req.content_type):
-            content = "&".join([k + "=" + backend_req.params[k] for k in backend_req.params])
+        if common.TYPE_URL_ENCODED in backend_req.content_type or '':
+            content = urllib.urlencode(backend_req.params)
         else:
             content = backend_req.stream
         return request.Request(

--- a/hammock/common.py
+++ b/hammock/common.py
@@ -33,6 +33,7 @@ TYPE_JSON = 'application/json'
 TYPE_XML = 'application/xml'
 TYPE_TEXT_PLAIN = 'text/plain'
 TYPE_OCTET_STREAM = 'application/octet-stream'
+TYPE_URL_ENCODED = 'application/x-www-form-urlencoded'
 TOKEN_ENTRY = 'X-Auth-Token'
 ID_LETTERS = (string.lowercase if six.PY2 else string.ascii_lowercase) + string.digits
 ENCODING = 'utf-8'

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -1,0 +1,43 @@
+# pylint: disable=W0212
+from __future__ import absolute_import
+import tests.base as base
+import hammock.common as common
+
+from hammock.backends._falcon import Falcon
+
+
+class TestRequestBody(base.TestBase):
+
+    class TestFalconRequest(object):
+        def __init__(self, method, url, headers, content_type, params=None, stream=None):
+            self.method = method
+            self.url = url
+            self.headers = headers
+            self.content_type = content_type
+            self.params = params
+            self.stream = stream
+            self.url_params = {}
+
+    def test_url_encoded_body(self):
+        params_url_encoded = {
+            'Action': 'DescribeInstances',
+            'Version': '2016-11-15'
+        }
+        header_url_encoded = {common.CONTENT_TYPE: common.TYPE_URL_ENCODED}
+        backend_req = self.TestFalconRequest(
+            "POST", "http://test/", header_url_encoded,
+            common.TYPE_URL_ENCODED, params_url_encoded)
+        hammock_request = Falcon._req_from_backend(backend_req, {})
+        self.assertEqual("Action=DescribeInstances&Version=2016-11-15",
+                         hammock_request.content)
+
+        backend_req.params = {}
+        hammock_request = Falcon._req_from_backend(backend_req, {})
+        self.assertEqual("", hammock_request.content)
+
+        backend_req.headers = {common.CONTENT_TYPE: common.TYPE_JSON}
+        backend_req.content_type = common.TYPE_JSON
+        test_stream = "This takes place of a streaming object"
+        backend_req.stream = test_stream
+        hammock_request = Falcon._req_from_backend(backend_req, {})
+        self.assertEqual(test_stream, hammock_request.content)


### PR DESCRIPTION
When creating a hammock request the body is not populated when the
backend request is an 'application/x-www-form-urlencoded' content
type.

The body from the backend request is exposed as params for the
urlencoded content type.  The body content should be reconstituted as
a string as per the original backend request.

Based on the content type the reconstituted string or the original
backend request stream will be passed into the constructor of the
hammock request.

Added a constant for the urlencoded type and a unit test.