### PR TITLE
BK-4944: Add the CLIENT_VAR_NAME class var

### DIFF
--- a/hammock/resource.py
+++ b/hammock/resource.py
@@ -33,6 +33,12 @@ class Resource(object):
     #   otherwise, the value will be the command name.
     CLI_COMMAND_NAME = None
 
+    # CLIENT_VAR_NAME:
+    # change the name of the member name of the resource in the python client
+    #   if None, the name will be set to lower-case, with underscores.
+    #   otherwise, the value will be the member name
+    CLIENT_VAR_NAME = None
+
     def __init__(self, **resource_params):
         self.params = resource_params
         self._specs = {}
@@ -148,7 +154,7 @@ class Resource(object):
 
     @classmethod
     def client_variable_name(cls):
-        return names.to_variable_name(cls.name())
+        return cls.CLIENT_VAR_NAME or names.to_variable_name(cls.name())
 
     @classmethod
     def client_class_name(cls):


### PR DESCRIPTION
This is becuase the "VMs" class got a "v_ms" member name.
Setting this will give the ability to override the member name in the python client